### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Building Docker Image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           # 下方的name格式为：Docker Hub ID/自定义镜像名称
           name: fergrtrwear/ggg


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore